### PR TITLE
Bugfix: race condition locks up neopixels

### DIFF
--- a/components/neopixel/neopixel.c
+++ b/components/neopixel/neopixel.c
@@ -409,10 +409,8 @@ void np_show(pixel_settings_t *px, rmt_channel_t channel)
 	RMT.conf_ch[RMTchannel].conf1.mem_rd_rst = 1;
 	RMT.conf_ch[RMTchannel].conf1.tx_start = 1;
 
-	// Wait for operation to finish
-	if (xSemaphoreTake(neopixel_sem, 0) == pdTRUE) {
-		xSemaphoreTake(neopixel_sem, portMAX_DELAY);
-	}
+	// Wait for operation to finish (isr gives semaphore)
+	xSemaphoreTake(neopixel_sem, portMAX_DELAY);
 	xSemaphoreGive(neopixel_sem);
 }
 


### PR DESCRIPTION
A misunderstanding on the effect of passing 0 as timeout caused a deadlock when sending data.

* Replace polling+taking with taking+giving
* Clarify why we take semaphore twice in function without first giving